### PR TITLE
chore(clib.json): make clib friendly

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,0 +1,10 @@
+{
+  "name": "buffet",
+  "version": "0.1.0",
+  "repo": "alcover/buffet",
+  "src": [
+    "src/buffet.c",
+    "src/buffet.h",
+    "src/log.h"
+  ]
+}


### PR DESCRIPTION
so we can install `buffer` with https://github.com/clibs/clib

I can install from my fork:

```sh
clib install jwerle/buffet@main
```
```
$ tree deps/
deps/
└── buffet
    ├── buffet.c
    ├── buffet.h
    ├── clib.json
    └── log.h

1 directory, 4 files
```